### PR TITLE
Removing GitHub Jobs and adding DevITjobs instead 

### DIFF
--- a/job-boards/job-boards/list-of-boards.md
+++ b/job-boards/job-boards/list-of-boards.md
@@ -68,7 +68,7 @@
 **Software Development**
 
 - [Honeypot.io](https://www.honeypot.io/pages/for_employers)
-- [GitHub](https://jobs.github.com)
+- [DevITJobs.us](https://devitjobs.us/) / [DevITJobs.uk](https://devitjobs.uk/)
 - [BlablaDev](https://blabladev.eu)
 - [Smashing **Magazine**](http://jobs.smashingmagazine.com)
 - [arstechnica](http://jobs.arstechnica.com)


### PR DESCRIPTION
GitHub jobs does not exist anymore: https://github.blog/changelog/2021-04-19-deprecation-notice-github-jobs-site

