### PR TITLE
Add Next Crypto Jobs

### DIFF
--- a/applications-and-job-postings/job-boards.md
+++ b/applications-and-job-postings/job-boards.md
@@ -524,6 +524,7 @@ Want to work at a YC-backed startup? If yes, this is your go-to place because it
 - [CryptoJobs](https://crypto.jobs)
 - [Blockew](https://blockew.com)
 - [Cryptocurrency Jobs](https://cryptocurrencyjobs.co)
+- [Next Crypto Jobs](https://nextcryptojobs.com/)
 
 ### Design
 


### PR DESCRIPTION
We are exclusive Crypto Job Board for professionals in blockchain & cryptocurrencies. We are a rapidly growing job board for blockchain and crypto jobs. We request you to please mention us under Block chain Job boards. https://nextcryptojobs.com/