### PR TITLE
Update README.md

### DIFF
--- a/job-boards/job-boards/README.md
+++ b/job-boards/job-boards/README.md
@@ -153,6 +153,7 @@
 - [JavaScript Jobs](https://jobs.date-fns.org)
 - [Jobs in JS](https://jobsinjs.com)
 - [R-users](https://www.r-users.com)
+- [JavaProHire](https://javaprohire.com)
 
 ## Remote
 


### PR DESCRIPTION
Add JavaProHire (https://javaprohire.com), a job board dedicated to Java developers. All the jobs are hand-picked, with no middlemen involved, and they feature clear salary ranges. We aim to create a seamless job search experience for both Java developers and recruiters.